### PR TITLE
qtwebengine 6.7.2: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,5 @@ build_parameters:
 
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f
+  - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/843e6a0

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,4 +3,4 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f
-  - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/843e6a0
+# channels:
+#   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+#   - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f
+#   - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/843e6a0

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# channels:
-#   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
-#   - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f
-#   - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/843e6a0
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/0896de1
+  - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/73a7435

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,12 @@
 @REM https://bugreports.qt.io/browse/QTBUG-107009
 set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
 
+REM Copy transport_security_state_static.h to solve the problem with generating it from archive.
+if exist "pregenerated_files\transport_security_state_static.h" (
+    mkdir -p %SRC_DIR%\build\src\core\Release\AMD64\gen\net\http\
+    copy "pregenerated_files\transport_security_state_static.h" "%SRC_DIR%\build\src\core\Release\AMD64\gen\net\http\"
+)
+
 :: QT_FEATURE_webengine_system_icu has to be OFF or else icudtl.dat doesn't get installed
 :: https://github.com/qt/qtwebengine/blob/6.7.2/src/core/api/CMakeLists.txt#L171
 cmake -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,7 @@ MACOSX_SDK_VERSION:
   - '11.3'                                                   # [osx]
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx]
-c_compiler:
-  - vs2022  # [win]
-cxx_compiler:
-  - vs2022  # [win]
+# c_compiler:
+#   - vs2022  # [win]
+# cxx_compiler:
+#   - vs2022  # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,8 @@ MACOSX_SDK_VERSION:
   - '11.3'                                                   # [osx]
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx]
-# c_compiler:
-#   - vs2022  # [win]
-# cxx_compiler:
-#   - vs2022  # [win]
+# vs2019 fails with the error "C2061: syntax error: identifier 'FILE_INFO_BY_HANDLE_CLASS'""
+c_compiler:
+  - vs2022  # [win]
+cxx_compiler:
+  - vs2022  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,7 +131,7 @@ requirements:
     - libxslt {{ libxslt }}        # [win]
     # Needs to be in hosts to allow QtPdf to build but is really a build dependency so no need to add to runtime deps.
     - html5lib 1.1
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - minizip 4.0.3
     - poppler 24
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   - url: https://github.com/qt/qtwebengine/archive/refs/tags/v{{ version }}.tar.gz
   # TODO: Use official releases page again once moving to a LTS.
   #  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 551bb9bc8734b13f1bed8888917d930008f3976ca12171a25fffbc2964eacce4
+    sha256: cd89db1a53626da4c71271fe5edaaf4de176d39af448151633368f1aee22a687
     folder: {{ name }}
     patches:
       - patches/0001-chromium-add-conda-CDT-include-paths-to-include_dirs.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,8 @@ source:
 build:
   number: 1
   skip: True  # [s390x]
-  skip: True  # [osx and x86_64]
+  # TODO: debug win
+  skip: True  # [osx and x86_64 or not win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
   ignore_run_exports_from:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: c7755875594d8be382b07bf3634d44fd77012805794d8b588891709a6405ffd1
+  - url: https://github.com/qt/qtwebengine/archive/refs/tags/v{{ version }}.tar.gz
+  # TODO: Use official releases page again once moving to a LTS.
+  #  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+    sha256: 551bb9bc8734b13f1bed8888917d930008f3976ca12171a25fffbc2964eacce4
     folder: {{ name }}
     patches:
       - patches/0001-chromium-add-conda-CDT-include-paths-to-include_dirs.patch
@@ -30,6 +32,10 @@ source:
     url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-headers-5.14.0-573.el9.aarch64.rpm  # [linux and aarch64]
     sha256: 5387dac519fac54cb0afb5e55997d5c535c4c9bca82cad26d8e164a6a613acf6  # [linux and x86_64]
     sha256: 4a7a5d00168e9c6949e9b3e3c4aa684aa9e8e2ffedf66e1c59b6d3f3986b862d  # [linux and aarch64]
+
+  - url: https://raw.githubusercontent.com/qt/qtwebengine-chromium/refs/heads/33.0.1750.170-based/chromium/net/http/transport_security_state_static.h  # [win]
+    sha256: 1648f487ae775518b4ec171666d028222f57e40d7d69fb2a1d3e6cc7282af582  # [win]
+    folder: pregenerated_files  # [win]
 
 build:
   number: 1
@@ -131,7 +137,7 @@ requirements:
     - libxslt {{ libxslt }}        # [win]
     # Needs to be in hosts to allow QtPdf to build but is really a build dependency so no need to add to runtime deps.
     - html5lib 1.1
-    - libtiff {{ libtiff }}
+    - libtiff 4.7.0
     - minizip 4.0.3
     - poppler 24
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtwebengine" %}
-{% set version = "6.7.2" %}
+{% set version = "6.7.3" %}
 
 package:
   name: {{ name }}
@@ -8,26 +8,32 @@ package:
 source:
   - url: https://github.com/qt/qtwebengine/archive/refs/tags/v{{ version }}.tar.gz
   # TODO: Use official releases page again once moving to a LTS.
-  #  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: cd89db1a53626da4c71271fe5edaaf4de176d39af448151633368f1aee22a687
+#  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+    sha256: 551bb9bc8734b13f1bed8888917d930008f3976ca12171a25fffbc2964eacce4
     folder: {{ name }}
+    patches:
+      - patches/0003-allow-building-with-non-apple-clang-version.patch
+      - patches/0012-add-gn-args-for-libxslt-and-libwebp.patch
+
+  # TODO: Remove this and move all these patches back to official release source once moving to a LTS.
+  # Hash came from https://github.com/qt/qtwebengine/tree/v{{ version }}/src 3rdparty submodule.
+  - url: https://github.com/qt/qtwebengine-chromium/archive/45bdfbd7721749beea9abd18467465e4c9026559.tar.gz
+    sha256: 275135326fb3036f54ec6b7c8b93b951faf68d90cb9ddea361c96d1215721b42
+    folder: {{ name }}/src/3rdparty
     patches:
       - patches/0001-chromium-add-conda-CDT-include-paths-to-include_dirs.patch
       - patches/0002-chromium-force-bundled-libdrm-for-linux.patch
-      - patches/0003-allow-building-with-non-apple-clang-version.patch
       - patches/0004-chromium-force-settings-to-build-without-xcode.patch
       - patches/0005-chromium-avoid-using-macos-12-13-14-symbols.patch
       - patches/0006-chromium-added-missing-headers.patch
       - patches/0007-chromium-disable-glib-usage-for-linux-aarch64.patch
       - patches/0008-chromium-fix-readelf-path.patch
-      - patches/0009-chromium-work-around-msvc-17.10-bug.patch
       # https://github.com/carsten-grimm-at-ipolog/vcpkg/blob/master/ports/qtwebengine/add-include-string.patch
       - patches/0010-gn-add-include-string.patch                  # [win]
       - patches/0011-use-binary-input-for-gperf-on-Windows.patch  # [win]
-      - patches/0012-add-gn-args-for-libxslt-and-libwebp.patch
+      - patches/0013-Disable-ScreenCaptureKit-on-OSX.patch        # [osx]
 
   - folder: kernel_headers  # [linux]
-    # Note: these URL can be deleted by the CentOS in a few months
     url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-headers-5.14.0-573.el9.x86_64.rpm    # [linux and x86_64]
     url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-headers-5.14.0-573.el9.aarch64.rpm  # [linux and aarch64]
     sha256: 5387dac519fac54cb0afb5e55997d5c535c4c9bca82cad26d8e164a6a613acf6  # [linux and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,11 @@ source:
       - patches/0012-add-gn-args-for-libxslt-and-libwebp.patch
 
   - folder: kernel_headers  # [linux]
-    url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-headers-5.14.0-547.el9.x86_64.rpm    # [linux and x86_64]
-    url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-headers-5.14.0-547.el9.aarch64.rpm  # [linux and aarch64]
-    sha256: def18a899bfe85c17e9bc1a5512930f100ffc18a7eb233a8d1017b14fd7b547c  # [linux and x86_64]
-    sha256: f254eec5d3166d02e08ad4cc36f2bc5bf75a952fe06f9a2df1721783ee6f48b1  # [linux and aarch64]
+    # Note: these URL can be deleted by the CentOS in a few months
+    url: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-headers-5.14.0-573.el9.x86_64.rpm    # [linux and x86_64]
+    url: https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/kernel-headers-5.14.0-573.el9.aarch64.rpm  # [linux and aarch64]
+    sha256: 5387dac519fac54cb0afb5e55997d5c535c4c9bca82cad26d8e164a6a613acf6  # [linux and x86_64]
+    sha256: 4a7a5d00168e9c6949e9b3e3c4aa684aa9e8e2ffedf66e1c59b6d3f3986b862d  # [linux and aarch64]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     sha256: f254eec5d3166d02e08ad4cc36f2bc5bf75a952fe06f9a2df1721783ee6f48b1  # [linux and aarch64]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [s390x]
   skip: True  # [osx and x86_64]
   run_exports:
@@ -129,7 +129,7 @@ requirements:
     - libxslt {{ libxslt }}        # [win]
     # Needs to be in hosts to allow QtPdf to build but is really a build dependency so no need to add to runtime deps.
     - html5lib 1.1
-    - libtiff {{ libtiff }}
+    - libtiff 4.7.0
     - minizip 4.0.3
     - poppler 24
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7599](https://anaconda.atlassian.net/browse/PKG-7599) 
- [Upstream repository](https://github.com/qt/qtwebengine/tree/v6.7.2)

### Explanation of changes:

- Update kernel-headers urls, because old ones are removed by CentOS and replaced with new build numbers 
- Add a comment that `vs2019 fails with the error "C2061: syntax error: identifier 'FILE_INFO_BY_HANDLE_CLASS'""`
- Bump the build number to 1
- Pin libtiff in host



[PKG-7599]: https://anaconda.atlassian.net/browse/PKG-7599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ