### PR TITLE
Update to v6.9.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-pkg_build_image_tag: main-rockylinux-8
-
-build_env_vars:
-  ANACONDA_ROCKET_GLIBC: '2.28'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,8 +30,9 @@ if [[ "${target_platform}" == linux-* ]]; then
   # find unvendored libraries in our host prefix.
   export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}"
 else
-  # webrtc controls ScreenCaptureKit on Mac, which we don't have right now.
-  #
+  # Make sure the PBP graph includes env vars we're using in patches.
+  echo ${OSX_SDK_DIR}
+
   # Webenginedriver is just used for tests and does not link against vendored zlib correctly.
   CMAKE_ARGS="
     ${CMAKE_ARGS}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,9 @@
 # https://doc.qt.io/qt-6/macos.html
 c_stdlib_version:
-  - 13.2           # [osx]
+  - 12.3           # [osx]
   - 2022.12        # [win]
-OSX_SDK_VER:
-  - 14.5
+OSX_SDK_VER:       # [osx]
+  - 14.5           # [osx]
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
@@ -18,11 +18,7 @@ c_compiler_version:    # [osx]
 cxx_compiler_version:  # [osx]
   - 17                 # [osx]
 
-# Need at least a 12.0 host or else tests will fail.
-extra_labels_for_os:
-  osx-arm64: [ventura]
-
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
-# 11.1 sysroot.
+# 12.1 sysroot.
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtwebengine" %}
-{% set version = "6.9.1" %}
+{% set version = "6.9.2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 787dfde22b348f6d620f2207ed7e32ad0a5389373182614272de28ff3f91c26c
+    sha256: 99cb0792abc2e39b299d73d8e2aa076b9ebcd55c3f4a4b5fd514eef5a62d03ab
     folder: {{ name }}
     patches:
       - patches/0001-gn-add-conda-paths.patch
@@ -19,10 +19,11 @@ source:
       - patches/0006-disable-newer-glibc-features.patch                    # [linux and aarch64]
       - patches/0008-chromium-fix-readelf-path.patch                       # [linux]
       - patches/0011-use-binary-input-for-gperf-on-Windows.patch           # [win]
-#      - patches/0013-disable-screencapturekit-on-osx.patch                 # [osx]
+      - patches/0013-disable-screencapturekit-on-osx.patch                 # [osx]
 
 build:
   number: 0
+  # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
   ignore_run_exports_from:
@@ -124,9 +125,6 @@ requirements:
     - openjpeg {{ openjpeg }}
     - re2 {{ re2 }}
     - snappy {{ snappy }}
-  run_constrained:
-    - qt-main >={{ version }},<7
-    - qt >={{ version }},<7
 
 test:
   requires:

--- a/recipe/patches/0013-disable-screencapturekit-on-osx.patch
+++ b/recipe/patches/0013-disable-screencapturekit-on-osx.patch
@@ -1,14 +1,43 @@
-From 70656f460cd46ccb2213e3cc88af7491134717c2 Mon Sep 17 00:00:00 2001
+From 2f1400676c91ae26a80c0f72d090d2208ff2ebbc Mon Sep 17 00:00:00 2001
 From: Brian Wing <bwing@anaconda.com>
-Date: Thu, 27 Mar 2025 13:56:53 -0400
+Date: Thu, 18 Sep 2025 09:22:13 -0400
 Subject: [PATCH] Disable ScreenCaptureKit on OSX
 
 ---
- src/3rdparty/chromium/media/media_options.gni | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/3rdparty/chromium/content/browser/BUILD.gn                                           | 2 ++
+ src/3rdparty/chromium/content/browser/media/capture/native_screen_capture_picker_mac.mm  | 3 +--
+ src/3rdparty/chromium/media/media_options.gni                                            | 2 +-
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/3rdparty/chromium/content/browser/BUILD.gn b/src/3rdparty/chromium/content/browser/BUILD.gn
+index ce2c7bc8d989..bbdef041862c 100644
+--- a/src/3rdparty/chromium/content/browser/BUILD.gn
++++ b/src/3rdparty/chromium/content/browser/BUILD.gn
+@@ -2856,6 +2856,8 @@ jumbo_source_set("browser") {
+         sources -= [
+           "media/capture/screen_capture_kit_device_mac.h",
+           "media/capture/screen_capture_kit_device_mac.mm",
++          "media/capture/screen_capture_kit_device_utils_mac.h",
++          "media/capture/screen_capture_kit_device_utils_mac.mm",
+           "media/capture/screen_capture_kit_fullscreen_module.h",
+           "media/capture/screen_capture_kit_fullscreen_module.mm",
+         ]
+diff --git a/src/3rdparty/chromium/content/browser/media/capture/native_screen_capture_picker_mac.mm b/src/3rdparty/chromium/content/browser/media/capture/native_screen_capture_picker_mac.mm
+index 0d6a3d1932e9..9dbcd8e87c6b 100644
+--- a/src/3rdparty/chromium/content/browser/media/capture/native_screen_capture_picker_mac.mm
++++ b/src/3rdparty/chromium/content/browser/media/capture/native_screen_capture_picker_mac.mm
+@@ -206,8 +206,7 @@ NativeScreenCapturePickerMac::CreateDevice(const DesktopMediaID& source) {
+     cached_content_filters_[source_id] = filter;
+   }
+
+-  std::unique_ptr<media::VideoCaptureDevice> device =
+-      CreateScreenCaptureKitDeviceMac(source, filter);
++  std::unique_ptr<media::VideoCaptureDevice> device = nullptr;
+   return device;
+ }
 
 diff --git a/src/3rdparty/chromium/media/media_options.gni b/src/3rdparty/chromium/media/media_options.gni
-index e1110f70170d..038cc5cacf63 100644
+index 9eb703e67af7..a208b450689f 100644
 --- a/src/3rdparty/chromium/media/media_options.gni
 +++ b/src/3rdparty/chromium/media/media_options.gni
 @@ -132,7 +132,7 @@ declare_args() {
@@ -21,4 +50,4 @@ index e1110f70170d..038cc5cacf63 100644
 
  # Use another declare_args() to allow dependence on args defined above.
 --
-2.47.2
+2.50.1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -7,7 +7,10 @@ pushd test
 
 # Ensure make can find a compiler.
 ln -s ${GXX} g++
-export PATH=$PREFIX/bin/xc-avoidance:${PWD}:${PATH}
+export PATH=${PWD}:${PATH}
+
+# Keep QMake from trying to detect the SDK in the wrong place in CI.
+export QT_MAC_SDK_NO_VERSION_CHECK=1
 
 # Only test that this builds: -d for debug, -Wall for warnings, -Wparser for parser warnings
 qmake6 -Wall -Wparser qtwebengine.pro

--- a/recipe/test/qtwebengine.pro
+++ b/recipe/test/qtwebengine.pro
@@ -5,5 +5,9 @@ RESOURCES += qml.qrc
 CONFIG+=sdk_no_version_check
 
 unix {
-    LIBS += -L${PREFIX}/lib
+    LIBS += -L$$(PREFIX)/lib
+}
+mac {
+    QMAKE_MACOSX_DEPLOYMENT_TARGET=$$(c_stdlib_version)
+    QMAKE_MAC_SDK=macosx$$(OSX_SDK_VER)
 }


### PR DESCRIPTION
qtwebengine 6.9.2

**Destination channel:** defaults

### Links

- [PKG-8694](https://anaconda.atlassian.net/browse/PKG-8694)
- [Upstream repository](https://github.com/qt/qtwebengine/tree/v6.9.2)
- [Upstream changelog/diff](https://github.com/qt/qtwebengine/compare/v6.9.1...v6.9.2)

### Explanation of changes:

- Fixed OSX ScreenCaptureKit patch to alllow building on older macOS CI runners again
  - Relaxed minimum macOS runtime version to match
- Added necessary QMake flags to test file that ensures we use the right SDK
- Relaxed runtime Qt pinnings to match other Qt modules

https://package-build.anaconda.com/v1/graph/cd8664bb-0a67-4dd0-95d4-ee454b1dd358

[PKG-8694]: https://anaconda.atlassian.net/browse/PKG-8694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ