### PR TITLE
Rebuild against libvpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# qtwebengine-feedstock
+About qtwebengine-feedstock
+=======================
+
+Feedstock license: [BSD-3-Clause](LICENSE)
+
+Home: [<home_url>](https://github.com/qt/qtwebengine)
+
+Package license: LGPL-3.0-only
+
+Summary: Cross-platform application and UI framework webengine libraries.
+
+
+Current release info
+====================
+
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-qtwebengine-green.svg)](https://anaconda.org/anaconda/qtwebengine) | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/qtwebengine.svg)](https://anaconda.org/anaconda/qtwebengine) | [![Conda Version](https://img.shields.io/conda/vn/anaconda/qtwebengine.svg)](https://anaconda.org/anaconda/qtwebengine) | [![Conda Platforms](https://img.shields.io/conda/pn/anaconda/qtwebengine.svg)](https://anaconda.org/anaconda/qtwebengine) |
+
+Installing qtwebengine
+==================
+
+Installing `qtwebengine` from the main channel can be achieved by:
+
+```
+conda install qtwebengine
+```
+
+It is possible to list all of the versions of `qtwebengine` available on your platform with `conda`:
+
+```
+conda search qtwebengine
+```

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,7 @@ c_stdlib_version:
   - 12.3           # [osx]
   - 2022.12        # [win]
 OSX_SDK_VER:       # [osx]
-  - 14.5           # [osx]
+  - 15             # [osx]
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
@@ -14,11 +14,11 @@ cxx_compiler:  # [win]
 # XCode 15.0 came with SDK 14.0 and clang 15
 # https://en.wikipedia.org/wiki/Xcode
 c_compiler_version:    # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 cxx_compiler_version:  # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
 # 12.1 sysroot.
 CONDA_BUILD_SYSROOT:
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [osx and arm64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
       - patches/0013-disable-screencapturekit-on-osx.patch                 # [osx]
 
 build:
-  number: 0
+  number: 1
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
qtwebengine 6.9.2

**Destination channel:** Main

### Links

- [PKG-10489](https://anaconda.atlassian.net/browse/PKG-10489) 
- [Upstream repository](https://github.com/qt/qtwebengine/tree/v6.9.2  )

### Explanation of changes:

- Rebuild agains libvpx
- Update README
- Update compiler's version


[PKG-10489]: https://anaconda.atlassian.net/browse/PKG-10489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ