### PR TITLE
Fixing build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 @REM https://bugreports.qt.io/browse/QTBUG-107009
 set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
-
+subst Y: "%SRC_DIR%"
 del /S /Q /F %LIBRARY_INC%\openssl
 del /S /Q /F %LIBRARY_INC%\absl
 del /S /Q /F %LIBRARY_INC%\zlib.h
@@ -22,7 +22,7 @@ del /S /Q /F %LIBRARY_INC%\jpeglib.h
 :: Need at least ffmpeg v7.0 to unvendor on Windows.
 :: Need at least libpng v1.6.43 to unvendor on Windows.
 :: Need at least zlib v1.3.0 to unvendor on Windows.
-cmake --log-level STATUS -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
+cmake --log-level STATUS -S"Y:\%PKG_NAME%" -B"Y:\build" -GNinja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,10 +15,10 @@ cxx_compiler:  # [win]
 # https://en.wikipedia.org/wiki/Xcode
 c_compiler_version:
   - 20                 # [osx]
-  - 11                 # [linux]
+  # - 11                 # [linux]
 cxx_compiler_version:
   - 20                 # [osx]
-  - 11                 # [linux]
+  # - 11                 # [linux]
 
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
 # 12.1 sysroot.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 # https://doc.qt.io/qt-6/macos.html
 c_stdlib_version:
-  - 12.3           # [osx]
+  - 15.2           # [osx]
   - 2022.12        # [win]
 OSX_SDK_VER:       # [osx]
   - 15             # [osx]
@@ -13,10 +13,12 @@ cxx_compiler:  # [win]
 
 # XCode 15.0 came with SDK 14.0 and clang 15
 # https://en.wikipedia.org/wiki/Xcode
-c_compiler_version:    # [osx]
+c_compiler_version:
   - 20                 # [osx]
-cxx_compiler_version:  # [osx]
+  - 11                 # [linux]
+cxx_compiler_version:
   - 20                 # [osx]
+  - 11                 # [linux]
 
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
 # 12.1 sysroot.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 # https://doc.qt.io/qt-6/macos.html
 c_stdlib_version:
-  - 15.2           # [osx]
+  - 12.3           # [osx]
   - 2022.12        # [win]
 OSX_SDK_VER:       # [osx]
   - 15             # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,10 +15,8 @@ cxx_compiler:  # [win]
 # https://en.wikipedia.org/wiki/Xcode
 c_compiler_version:
   - 20                 # [osx]
-  # - 11                 # [linux]
 cxx_compiler_version:
   - 20                 # [osx]
-  # - 11                 # [linux]
 
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
 # 12.1 sysroot.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "qtwebengine" %}
 {% set version = "6.9.2" %}
 
-
 package:
   name: {{ name }}
   version: {{ version }}
@@ -18,6 +17,7 @@ source:
       - patches/0005-set-rpath-on-generators-on-osx.patch                  # [osx]
       - patches/0006-disable-newer-glibc-features.patch                    # [linux and aarch64]
       - patches/0008-chromium-fix-readelf-path.patch                       # [linux]
+      - patches/0009-fix-chromium-header.patch                             # [linux]
       - patches/0011-use-binary-input-for-gperf-on-Windows.patch           # [win]
       - patches/0013-disable-screencapturekit-on-osx.patch                 # [osx]
 

--- a/recipe/patches/0009-fix-chromium-header.patch
+++ b/recipe/patches/0009-fix-chromium-header.patch
@@ -1,0 +1,12 @@
+diff --git a/src/3rdparty/chromium/third_party/minigbm/src/dri.c b/src/3rdparty/chromium/third_party/minigbm/src/dri.c
+index 27331cf1021..3296f85bdbc 100644
+--- a/src/3rdparty/chromium/third_party/minigbm/src/dri.c
++++ b/src/3rdparty/chromium/third_party/minigbm/src/dri.c
+@@ -7,6 +7,7 @@
+ #ifdef DRV_AMDGPU
+ 
+ #include <assert.h>
++#include <libgen.h>
+ #include <dlfcn.h>
+ #include <errno.h>
+ #include <fcntl.h>

--- a/recipe/patches/0009-fix-chromium-header.patch
+++ b/recipe/patches/0009-fix-chromium-header.patch
@@ -1,12 +1,20 @@
-diff --git a/src/3rdparty/chromium/third_party/minigbm/src/dri.c b/src/3rdparty/chromium/third_party/minigbm/src/dri.c
-index 27331cf1021..3296f85bdbc 100644
---- a/src/3rdparty/chromium/third_party/minigbm/src/dri.c
-+++ b/src/3rdparty/chromium/third_party/minigbm/src/dri.c
-@@ -7,6 +7,7 @@
- #ifdef DRV_AMDGPU
- 
+diff --git a/src/3rdparty/chromium/third_party/minigbm/src/drv.c b/src/3rdparty/chromium/third_party/minigbm/src/drv.c
+index 9cfdbfb82d5..0a5c4b6322e 100644
+--- a/src/3rdparty/chromium/third_party/minigbm/src/drv.c
++++ b/src/3rdparty/chromium/third_party/minigbm/src/drv.c
+@@ -4,6 +4,7 @@
+  * found in the LICENSE file.
+  */
  #include <assert.h>
 +#include <libgen.h>
- #include <dlfcn.h>
  #include <errno.h>
  #include <fcntl.h>
+ #include <pthread.h>
+@@ -17,7 +18,6 @@
+ 
+ #ifdef __ANDROID__
+ #include <cutils/log.h>
+-#include <libgen.h>
+ #endif
+ 
+ #include "drv_helpers.h"


### PR DESCRIPTION
qtwebengine  6.9.2

**Destination channel:** defaults

### Links

- [PKG-10489](https://anaconda.atlassian.net/browse/PKG-10489) 
- [Upstream repository](https://github.com/qt/qtwebengine/tree/v6.9.2#)

### Explanation of changes:

- Patch for chromium source file
- Alias for SRC_DIR to decrease amount of symbols in path.


[PKG-10489]: https://anaconda.atlassian.net/browse/PKG-10489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ