### PR TITLE
Rebuild against libxml2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -18,9 +18,10 @@ c_compiler_version:
 cxx_compiler_version:
   - 20                 # [osx]
 
-
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk  # [osx]
 
 libxml2:
   - 2.14.4
+libvulkan:
+  - 1.4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -21,3 +21,6 @@ cxx_compiler_version:
 
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk  # [osx]
+
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
       - patches/0012-v8-segmented-table-linux-aarch64-64kb.patch  # [linux and aarch64]
 
 build:
-  number: 0
+  number: 1
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
qtwebengine 6.11.0

**Destination channel:**  defaults

### Links

- [PKG-12531](https://anaconda.atlassian.net/browse/PKG-12531) 
- [Upstream repository](https://github.com/qt/qtwebengine/tree/v6.11.0)

### Explanation of changes:
- Rebuild against libxml2

[PKG-12531]: https://anaconda.atlassian.net/browse/PKG-12531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ